### PR TITLE
Fix the default z-index for popup windows when using the Hide Sidebar plugin

### DIFF
--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -1146,6 +1146,7 @@
   .ui-dialog.popup-anywhere {
     flex-grow: 1;
     box-shadow: 0 0 5px rgb(0 0 0 / 20%);
+    z-index: 100; /* Support for Hide Sidebar Plugin */
   }
 
   .ui-dialog.popup-anywhere .ui-dialog-titlebar-button-group {


### PR DESCRIPTION
This commit is a supplement to PR #54.