### PR TITLE
Add feature: Auto reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a plugin for Redmine. This plugin is designed to improve the user experi
 - Show only opened issues - Filter the issue list to show only open issues using a checkbox.
 - Simple menu bar - Simplify the top menu and application menu for a more compact experience.
 - Two pane mode - Split the screen into two panes for easier multitasking.
+- Auto reload - Automatically reload the page at the specified interval.
 - Fixes for RTL design - RTL design fixes for some pages (excluding Gantt chart).
 
 ## Installation

--- a/app/views/enhanced_ux/layouts/_auto_reload.html.erb
+++ b/app/views/enhanced_ux/layouts/_auto_reload.html.erb
@@ -1,0 +1,221 @@
+<!--
+// Path pattern:       (/issues($|/gantt)|/roadmap|/issue_note_list|/calendar|/versions/[0-9]+$|/activity|/news)
+// Insertion position: Head of all pages
+// Type:               HTML
+// Comment:            Auto reload
+-->
+<script>
+  $(() => {
+    const resourcesAll = {
+      en: {
+        autoReload: "Auto reload",
+        errorLoading: "Failed to reload the content.",
+        seconds: "seconds",
+        description: "Automatically reload the page at the specified interval.",
+      },
+      ja: {
+        autoReload: "自動更新",
+        errorLoading: "コンテンツの読み込みに失敗しました。",
+        seconds: "秒間隔",
+        description: "ページを指定の間隔で自動更新します。",
+      },
+    };
+    const resources =
+      resourcesAll[document.documentElement.lang] || resourcesAll["en"];
+
+    const intervals = [5, 10, 30, 60, 180, 300, 600];
+    const defaultInterval = 60;
+    let timerId = null;
+
+    async function reload() {
+      try {
+        if (window.ajaxUpdateIssueList) {
+          await window.ajaxUpdateIssueList();
+        } else {
+          location.reload();
+          return;
+          // TODO: Fetch the contents.
+          // Note: Conflicts with the other features and plugins.
+        }
+        appendCheckbox(); // Restore the check box
+        console.log(`[${new Date().toLocaleString()}] Reloaded.`);
+      } catch (error) {
+        console.error(error);
+        showError(resources.errorLoading);
+        enableAutoReload(false);
+      }
+    }
+
+    function showError(message) {
+      const $message = $("#auto_reload_message");
+      $message.text(message).show().attr("class", "").addClass("error");
+      $checkboxControl.css("opacity", 1);
+
+      setTimeout(() => {
+        $message.fadeOut(300, () => {
+          $checkboxControl.css("opacity", "");
+        });
+      }, 10000);
+    }
+
+    function selectIntervalItem(interval) {
+      $menu.find("li").each((i, e) => {
+        const $e = $(e);
+        if (parseInt($e.text()) === interval) {
+          $e.addClass("selected");
+        } else {
+          $e.removeClass("selected");
+        }
+      });
+    }
+
+    // Generate a toggle switch to enable/disable
+    const $checkbox = $('<input type="checkbox">').attr({
+      id: "enable_auto_reload",
+    });
+    const $message = $("<span>").attr("id", "auto_reload_message");
+
+    // Interval selection menu
+    const $menu = $("<ul>").attr({ id: "auto_reload_menu", title: "" });
+    intervals.forEach((i) => {
+      const $item = $(`<li><div>${i} ${resources.seconds}</div></li>`);
+      $menu.append($item);
+    });
+
+    const $checkboxControl = $("<div>")
+      .attr({ title: resources.description, id: "auto_reload_controller" })
+      .append($checkbox)
+      .append(
+        $("<label>")
+          .attr({ for: "enable_auto_reload", "data-i18n": "autoReload" })
+          .html(resources.autoReload)
+      )
+      .append($message)
+      .append($menu);
+
+    function enableAutoReload(state = true, interval = null) {
+      clearInterval(timerId);
+      timerId = null;
+
+      if (state) {
+        if (!interval || interval <= 0) interval = defaultInterval;
+        selectIntervalItem(interval);
+        timerId = setInterval(reload, interval * 1000);
+      } else {
+        selectIntervalItem(0);
+      }
+
+      $checkbox.prop("checked", state);
+      localStorage.setItem("autoReload", state ? interval : "0");
+    }
+
+    function appendCheckbox() {
+      if ($("#auto_reload_controller").length > 0) return;
+
+      if ($(".enable_2-pane_mode_box").length > 0) {
+        $(".enable_2-pane_mode_box").after($checkboxControl);
+      } else {
+        if (/\/versions\/[0-9]+$/.test(location.pathname)) {
+          $("#roadmap>h2+span.badge:first").after($checkboxControl);
+        } else {
+          $("#content>h2").append($checkboxControl);
+        }
+      }
+      $checkbox.on("change", function () {
+        enableAutoReload($(this).is(":checked"));
+      });
+      setupMenu();
+    }
+
+    function setupMenu() {
+      $checkboxControl.hover(
+        () => {
+          $menu.show().position({
+            my: "left top",
+            at: "left bottom",
+            of: $checkboxControl.find("label"),
+          });
+        },
+        () => {
+          setTimeout(() => {
+            $menu.hide();
+          });
+        }
+      );
+
+      $menu
+        .menu({
+          select: function (event, ui) {
+            enableAutoReload(true, parseInt(ui.item.text()));
+            setTimeout(() => {
+              $menu.hide();
+            });
+          },
+        })
+        .hide();
+    }
+
+    // Initialize
+    appendCheckbox();
+    const storedInterval = localStorage.getItem("autoReload");
+    if (
+      storedInterval &&
+      parseInt(storedInterval) &&
+      parseInt(storedInterval) !== 0
+    ) {
+      enableAutoReload(true, parseInt(storedInterval));
+    }
+  });
+</script>
+<style>
+  #auto_reload_controller {
+    display: inline-flex;
+    align-items: center;
+    opacity: 0.3;
+    &:hover {
+      opacity: 1;
+    }
+
+    #enable_auto_reload {
+      margin-left: 10px;
+      margin-right: 5px;
+      cursor: pointer;
+      height: 13px;
+      & + label {
+        font-size: 12px;
+        font-weight: normal;
+        cursor: pointer;
+      }
+    }
+    #auto_reload_message {
+      display: none;
+      margin: 1px 5px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 11px;
+      &.error {
+        color: red;
+        outline: 1px red solid;
+        background-color: #fdd;
+      }
+    }
+    #auto_reload_menu {
+      display: none;
+      position: absolute;
+      background-color: #fff;
+      border: 1px solid #ccc;
+      border-radius: 3px;
+      padding: 5px;
+      box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+      z-index: 1000;
+      font-size: 12px;
+      font-weight: normal;
+      li {
+        cursor: pointer;
+        &.selected {
+          background-color: #ddd;
+        }
+      }
+    }
+  }
+</style>

--- a/app/views/settings/_enhanced_ux_settings.html.erb
+++ b/app/views/settings/_enhanced_ux_settings.html.erb
@@ -141,6 +141,11 @@
     <%= check_box_tag 'settings[two_pane_mode]', '1', @settings[:two_pane_mode] == '1' %>
   </p>
   <p>
+    <label for="auto_reload">Auto reload:</label>
+    <input type="hidden" name="settings[auto_reload]" value="'0'">
+    <%= check_box_tag 'settings[auto_reload]', '1', @settings[:auto_reload] == '1' %>
+  </p>
+  <p>
     <label for="fixes_for_rtl_design">Fixes for RTL design:</label>
     <input type="hidden" name="settings[fixes_for_rtl_design]" value="'0'">
     <%= check_box_tag 'settings[fixes_for_rtl_design]', '1', @settings[:fixes_for_rtl_design] == '1' %>

--- a/init.rb
+++ b/init.rb
@@ -31,6 +31,7 @@ Redmine::Plugin.register :redmine_enhanced_ux do
         show_only_opened_issues: '1',
         simple_menu_bar: '1',
         two_pane_mode: '1',
+        auto_reload: '1',
         fixes_for_rtl_design: '1',
         local_storage_manager: '1',
       },

--- a/lib/enhanced_ux/hooks/view_layouts_base_html_head_hook.rb
+++ b/lib/enhanced_ux/hooks/view_layouts_base_html_head_hook.rb
@@ -109,6 +109,11 @@ module EnhancedUx
               tags << controller.render_to_string(partial: 'enhanced_ux/layouts/two_pane_mode')
             end
           end
+          if /(\/issues($|\/gantt)|\/roadmap|\/issue_note_list|\/calendar|\/versions\/[0-9]+$|\/activity|\/news)/.match?(path)
+            if Setting.plugin_redmine_enhanced_ux[:auto_reload] == '1'
+              tags << controller.render_to_string(partial: 'enhanced_ux/layouts/auto_reload')
+            end
+          end
 
           if Setting.plugin_redmine_enhanced_ux[:fixes_for_rtl_design] == '1'
             tags << stylesheet_link_tag("global/fixes_for_rtl_design", :plugin => "redmine_enhanced_ux", media: "all")


### PR DESCRIPTION
Add a feature to automatically reload the page at a specified interval.
![image](https://github.com/user-attachments/assets/b6654763-e557-4284-ab8c-364380dc60fd)

If AJAX updating (via the `ajaxUpdateIssueList` function) is enabled, background updating is supported; otherwise, the page will be reloaded.