### PR TITLE
Enhanced list operations for Wiki editing with keyboard shortcuts

### DIFF
--- a/assets/javascripts/wiki/enhanced_list_button.js
+++ b/assets/javascripts/wiki/enhanced_list_button.js
@@ -621,6 +621,13 @@
     return [currentBlockPrefix, selectedText, currentBlockSuffix];
   }
 
+  function getListDecorator(line) {
+    if (methods.isUl(line)) return ulDecorator;
+    if (methods.isOl(line)) return olDecorator;
+    if (methods?.isTl(line)) return tlDecorator;
+    return null;
+  }
+
   function handleTabKey(e, jsToolBarInstance) {
     const textarea = jsToolBarInstance.textarea;
 
@@ -648,39 +655,18 @@
       const line = selectedLines[i];
       const cursorPos =
         lineLengths.slice(0, i).reduce((a, b) => a + b, 0) + (i > 0 ? i : 0);
-      let flgDecorated = false;
-      if (methods.isUl(line)) {
+
+      const decorator = getListDecorator(line);
+      if (decorator) {
         e.preventDefault();
         if (!(e.shiftKey && tabCounts[i] === 0) || maxTabCount === 0) {
           textarea.setSelectionRange(
             startLine + cursorPos,
             startLine + cursorPos + line.length
           );
-          ulDecorator.call(jsToolBarInstance, e);
-          flgDecorated = true;
+          decorator.call(jsToolBarInstance, e);
         }
-      } else if (methods.isOl(line)) {
-        e.preventDefault();
-        if (!(e.shiftKey && tabCounts[i] === 0) || maxTabCount === 0) {
-          textarea.setSelectionRange(
-            startLine + cursorPos,
-            startLine + cursorPos + line.length
-          );
-          olDecorator.call(jsToolBarInstance, e);
-          flgDecorated = true;
-        }
-      } else if (methods.isTl(line)) {
-        e.preventDefault();
-        if (!(e.shiftKey && tabCounts[i] === 0) || maxTabCount === 0) {
-          textarea.setSelectionRange(
-            startLine + cursorPos,
-            startLine + cursorPos + line.length
-          );
-          tlDecorator.call(jsToolBarInstance, e);
-          flgDecorated = true;
-        }
-      }
-      if (flgDecorated) {
+
         countShifts[i] = e.shiftKey
           ? textarea.selectionEnd - (startLine + cursorPos + line.length)
           : textarea.selectionStart - (startLine + cursorPos);


### PR DESCRIPTION
This PR enhances list operations in Wiki editing.

### Features Added
- Enhanced automatic numbering updates for ordered lists (previously only worked when adding new lines)
- HOME key now moves cursor to the beginning of list item content
- Added support for Task Lists
- Added keyboard shortcuts for toggling task list checkboxes

### Keyboard Operations
- `Ctrl/Cmd + .`: Add/remove unordered list (UL) markers
- `Ctrl/Cmd + /`: Add/remove ordered list (OL) markers  
- `Ctrl/Cmd + ,`: Add/remove task list (TL) markers (only works in Markdown format)
- `Ctrl/Cmd + ;`: Toggle task list checkboxes (only works on task lists and Markdown format)
- `Tab`: Indent list items (only works on lists)
- `Shift + Tab`: Unindent list items, removes list markers when no further unindentation is possible (only works on lists)
- `Home`: Move cursor to the start of list item content when cursor is within item text
- `Enter`: Create new line with inherited list markers (auto-increments numbers for ordered lists)