### PR TITLE
Add support for Lazy Load History plugin

### DIFF
--- a/app/views/enhanced_ux/issues/_custom_issue.html.erb
+++ b/app/views/enhanced_ux/issues/_custom_issue.html.erb
@@ -1308,9 +1308,25 @@
 
           // Update content history tab
           if (updateHistory) {
+            const $newHistory = $("#tab-content-history", data).children();
+
+            // Support for Lazy Load History plugin
+            const $lazyLoadHistory = $("#history .lazy-load-history");
+            if ($lazyLoadHistory.length > 0) {
+              const $newLazyLoadHistory = $newHistory.filter(".lazy-load-history");
+              if ($newLazyLoadHistory.length > 0) {
+                const newLazyLoadHistoryNode = $newLazyLoadHistory.get(0);
+                $lazyLoadHistory.replaceWith(newLazyLoadHistoryNode);
+                window.lazyLoadHistory?.initContainer?.(newLazyLoadHistoryNode);
+              } else {
+                $lazyLoadHistory.remove();
+              }
+            }
+
             $("#tab-content-history")
               .empty()
-              .append($("#tab-content-history", data).children());
+              .append($newHistory.filter(":not(.lazy-load-history)"));
+
             $("#history>.tabs>ul>li>a.selected").click();
           }
 

--- a/app/views/enhanced_ux/issues/_custom_issue.html.erb
+++ b/app/views/enhanced_ux/issues/_custom_issue.html.erb
@@ -1308,24 +1308,26 @@
 
           // Update content history tab
           if (updateHistory) {
-            const $newHistory = $("#tab-content-history", data).children();
+            let $newHistory = $("#tab-content-history", data).children();
 
             // Support for Lazy Load History plugin
-            const $lazyLoadHistory = $("#history .lazy-load-history");
-            if ($lazyLoadHistory.length > 0) {
-              const $newLazyLoadHistory = $newHistory.filter(".lazy-load-history");
-              if ($newLazyLoadHistory.length > 0) {
-                const newLazyLoadHistoryNode = $newLazyLoadHistory.get(0);
-                $lazyLoadHistory.replaceWith(newLazyLoadHistoryNode);
-                window.lazyLoadHistory?.initContainer?.(newLazyLoadHistoryNode);
-              } else {
-                $lazyLoadHistory.remove();
-              }
-            }
+            $newHistory = $newHistory.filter(":not(.lazy-load-history)")
 
-            $("#tab-content-history")
-              .empty()
-              .append($newHistory.filter(":not(.lazy-load-history)"));
+            $newHistory.each((i, el) => {
+              const $newElem = $(el);
+              const id = $newElem.attr("id");
+              const $currentElem = $("#" + id);
+              if ($currentElem.length > 0) {
+                $currentElem.replaceWith($newElem);
+              } else {
+                // Detect notes order by checking the first history element existence, and insert new history accordingly
+                if (i === 0 && $(".tabs + .lazy-load-history").length === 0) {
+                  $newElem.prependTo("#tab-content-history");
+                } else {
+                  $newElem.appendTo("#tab-content-history");
+                }
+              }
+            });
 
             $("#history>.tabs>ul>li>a.selected").click();
           }


### PR DESCRIPTION
This PR includes the following fixes:
1. Fix duplication of the `Show more` button added by the `Lazy Load History` plugin (#227)
2. Preserve old notes after submitting `quick notes`