### PR TITLE
fix: stop storing issue title in localStorage

### DIFF
--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -56,6 +56,7 @@
         labelRowDirection: "Aligned in row direction",
         labelColumnDirection: "Aligned in column direction",
         messageCloseAllDialogs: "Close all dialogs?",
+        messageLoading: "Loading...",
       },
       ja: {
         labelClose: "閉じる",
@@ -81,6 +82,7 @@
         labelRowDirection: "行方向に整列",
         labelColumnDirection: "列方向に整列",
         messageCloseAllDialogs: "全てのダイアログを閉じますか？",
+        messageLoading: "読み込み中...",
       },
     };
     const resources = {
@@ -1024,10 +1026,21 @@
         if (states[location.pathname]?.dialogs?.length === 0) {
           delete states[location.pathname];
         }
+        
+        // Remove title from the state to avoid storing unnecessary data
+        const sanitizedStates = JSON.parse(JSON.stringify(states));
+        for (const [key, value] of Object.entries(sanitizedStates)) {
+          if (PopUp.specialStorageKeys.includes(key)) continue;
+          if (value.dialogs) {
+            value.dialogs.forEach((dialog) => {
+              delete dialog.title;
+            });
+          }
+        }
 
         localStorage.setItem(
           localStorageKeyPrefix + "popup-anywhere-state",
-          JSON.stringify(states));
+          JSON.stringify(sanitizedStates));
       }
 
       static restoreDialogState() {
@@ -1043,7 +1056,6 @@
           .forEach((dialogProps) => {
             try {
               new PopUp(
-                dialogProps.title,
                 dialogProps.src,
                 dialogProps.positionAt,
                 dialogProps.height,
@@ -1065,7 +1077,6 @@
       }
 
       constructor(
-        title,
         url,
         positionAt = null,
         height = PopUp.size.height,
@@ -1076,7 +1087,6 @@
       ) {
         if (!url) throw new Error("url must not be null");
 
-        this.title = title;
         this.url = url;
         this.positionAt = positionAt;
         this.height = height;
@@ -1086,7 +1096,7 @@
         this.fixed = fixed;
 
         this.$dialog = $("<div>")
-          .attr("title", title)
+          .attr("title", resources.messageLoading)
           .addClass("popup-anywhere-container")
           .data("height", this.height)
           .data("width", this.width);
@@ -1158,10 +1168,9 @@
         .on("click.popup-anywhere", targetLinkQueries, (e) => {
           if (e.ctrlKey) {
             const $anchor = $(e.target).closest("a");
-            const title = $anchor.text();
             const href = $anchor.attr("href");
             if (href && utils.isInternalUrl(href)) {
-              new PopUp(title, href);
+              new PopUp(href);
               e.preventDefault();
               e.stopPropagation();
             } else {


### PR DESCRIPTION
This pull request makes several improvements to the popup dialog system in the enhanced UX layout, focusing on better state management and user experience. The most significant changes remove the storage of popup dialog titles in local storage, ensuring only necessary data is persisted, and introduce a loading message for dialogs. Additionally, the `PopUp` class is refactored to no longer require a `title` parameter, simplifying its usage.

**State management improvements:**
* Dialog titles are now removed before saving state to local storage, preventing unnecessary data from being persisted and reducing storage usage (`_popup_anywhere.html.erb`).

**User experience enhancements:**
* Added a `messageLoading` resource in both English and Japanese, which is displayed as the dialog's title while content loads (`_popup_anywhere.html.erb`). [[1]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951R59) [[2]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951R85) [[3]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951L1089-R1099)

**Code simplification and refactoring:**
* The `PopUp` class and its instantiation no longer require a `title` parameter; instead, the loading message is used until content is available (`_popup_anywhere.html.erb`). [[1]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951L1046) [[2]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951L1068) [[3]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951L1079) [[4]](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951L1161-R1173)