### PR TITLE
Enhance settings panel with state management and UI improvements

### DIFF
--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -58,6 +58,9 @@
         labelInitialWidth: "Initial width",
         labelInitialHeight: "Initial height",
         labelMaxStoredStateCount: "Max stored state count",
+        descOverMaxStoredStateCount:
+          "If the number of stored states exceeds this value, " +
+          "the oldest states will be removed automatically.",
         labelDisablePopupInPopup: "Disable popup in popup",
         labelInheritPopupSizeFromActiveWindow: "Inherit size from active popup",
         labelReset: "Reset",
@@ -100,6 +103,8 @@
         labelInitialWidth: "初期幅",
         labelInitialHeight: "初期高さ",
         labelMaxStoredStateCount: "ルールの最大保持数",
+        descOverMaxStoredStateCount:
+          "ルールの最大保持数を超えた場合、古いルールから自動的に削除されます。",
         labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
         labelInheritPopupSizeFromActiveWindow:
           "アクティブなポップアップサイズを引き継ぐ",
@@ -111,7 +116,8 @@
         labelStoredStates: "保存済みのルール",
         labelNItems: "%{count} 件",
         messageRemoveThisState: "このルールを削除します",
-        messageActiveStateCannotBeRemoved: "アクティブなルールは削除できません。",
+        messageActiveStateCannotBeRemoved:
+          "アクティブなルールは削除できません。",
         messageCancelRemovingThisState: "このルールの削除をキャンセルします",
       },
     };
@@ -288,9 +294,18 @@
         "popup-anywhere-settings-panel-content",
       );
 
-      function generateSettingItem(labelText, id, $input, value = false) {
+      function generateSettingItem(
+        labelText,
+        id,
+        $input,
+        value = false,
+        labelTitle = null,
+      ) {
         const $container = $("<div>").addClass("setting-item");
         const $label = $("<label>").text(labelText).attr("for", id);
+        if (labelTitle) {
+          $label.attr("title", labelTitle);
+        }
         $input
           .attr("id", id)
           .prop(
@@ -401,6 +416,7 @@
             "pa_max_stored_state_count_settings",
             $("<input>").attr({ type: "number", min: 0, step: 1 }),
             settings.maxStoredStateCount,
+            resources.descOverMaxStoredStateCount,
           ),
         )
         .append(

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -63,6 +63,13 @@
         labelReset: "Reset",
         labelSave: "Save",
         labelCancel: "Cancel",
+        labelRemove: "Remove",
+        labelActive: "Active",
+        labelStoredStates: "Stored States",
+        labelNItems: "%{count} item(s)",
+        messageRemoveThisState: "Remove this state",
+        messageActiveStateCannotBeRemoved: "Active state can not be removed.",
+        messageCancelRemovingThisState: "Cancel removing this state",
       },
       ja: {
         labelClose: "閉じる",
@@ -92,13 +99,20 @@
         labelSettings: "設定",
         labelInitialWidth: "初期幅",
         labelInitialHeight: "初期高さ",
-        labelMaxStoredStateCount: "最大状態保持数",
+        labelMaxStoredStateCount: "ルールの最大保持数",
         labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
         labelInheritPopupSizeFromActiveWindow:
           "アクティブなポップアップサイズを引き継ぐ",
         labelReset: "リセット",
         labelSave: "保存",
         labelCancel: "キャンセル",
+        labelRemove: "削除",
+        labelActive: "アクティブ",
+        labelStoredStates: "保存済みのルール",
+        labelNItems: "%{count} 件",
+        messageRemoveThisState: "このルールを削除します",
+        messageActiveStateCannotBeRemoved: "アクティブなルールは削除できません。",
+        messageCancelRemovingThisState: "このルールの削除をキャンセルします",
       },
     };
     const resources = {
@@ -151,6 +165,13 @@
       // Remove unused parameters
       delete states["_default-width"];
       delete states["_default-height"];
+    }
+
+    function saveStatesToLocalStorage(newStates = states) {
+      localStorage.setItem(
+        localStorageKeyPrefix + "popup-anywhere-states",
+        JSON.stringify(newStates),
+      );
     }
 
     const svgIcons = new (class SVGIcons {
@@ -279,6 +300,83 @@
         return $container.append($label).append($input);
       }
 
+      function generateStoredStateListContainer() {
+        const $stateListContainer = $("<details>").addClass(
+          "state-list-container",
+        );
+        const $stateListOuter = $("<div>").addClass("state-list-outer");
+        const $stateList = $("<table>").addClass("state-list");
+        return $stateListContainer
+          .append($("<summary>").text(resources.labelStoredStates))
+          .append($stateListOuter.append($stateList));
+      }
+
+      let removeTargetStateKeys = [];
+      function updateStoredStateList() {
+        const $stateList = $settingsPanel.find(".state-list");
+        $stateList.empty();
+        Object.keys(states).forEach((key) => {
+          const $tr = $("<tr>");
+          const $tdKey = $("<td>")
+            .append(
+              key === location.pathname
+                ? $("<span>").text(key)
+                : $("<a>")
+                    .attr({
+                      href: key,
+                      target: "_blank",
+                    })
+                    .text(key),
+            )
+            .attr({
+              title: new Date(states[key]?.timeStamp).toLocaleString(),
+            });
+          const $tdItemCount = $("<td>")
+            .text(
+              resources.labelNItems.replace(
+                "%{count}",
+                states[key]?.dialogs?.length || 0,
+              ),
+            )
+            .attr(
+              "title",
+              states[key]?.dialogs
+                ?.map((dialog, index) => index + 1 + ": " + dialog.src)
+                .join("\n"),
+            );
+          const $tdAction = $("<td>").addClass("state-actions");
+          if (key === location.pathname) {
+            $tr.addClass("state-active");
+            $tdAction
+              .append($("<span>").text(resources.labelActive))
+              .attr("title", resources.messageActiveStateCannotBeRemoved);
+          } else if (removeTargetStateKeys.includes(key)) {
+            $tr.addClass("state-to-be-removed");
+            const $cancelBtn = $("<button>")
+              .text(resources.labelCancel)
+              .attr("title", resources.messageCancelRemovingThisState)
+              .on("click", () => {
+                removeTargetStateKeys = removeTargetStateKeys.filter(
+                  (k) => k !== key,
+                );
+                updateStoredStateList();
+              });
+            $tdAction.append($cancelBtn);
+          } else {
+            const $removeBtn = $("<button>")
+              .text(resources.labelRemove)
+              .attr("title", resources.messageRemoveThisState)
+              .on("click", () => {
+                removeTargetStateKeys.push(key);
+                updateStoredStateList();
+              });
+            $tdAction.append($removeBtn);
+          }
+          $tr.append($tdKey).append($tdItemCount).append($tdAction);
+          $stateList.append($tr);
+        });
+      }
+
       // Append settings to dialog
       $settingsPanel
         .append(
@@ -320,13 +418,15 @@
             $("<input>").attr("type", "checkbox"),
             settings.inheritPopupSizeFromActiveWindow,
           ),
-        );
+        )
+        .append($("<hr>"))
+        .append(generateStoredStateListContainer());
 
       const $dialog = $settingsPanel.dialog({
         autoOpen: false,
         title: "Popup Anywhere - " + resources.labelSettings,
         modal: true,
-        width: 350,
+        width: 500,
         resizable: false,
         buttons: [
           {
@@ -363,6 +463,13 @@
                 ).prop("checked"),
               });
               saveSettings();
+              if (removeTargetStateKeys.length > 0) {
+                removeTargetStateKeys.forEach((key) => {
+                  delete states[key];
+                });
+                removeTargetStateKeys = [];
+                saveStatesToLocalStorage();
+              }
               $dialog.dialog("close");
             },
           },
@@ -392,6 +499,9 @@
             "checked",
             settings.inheritPopupSizeFromActiveWindow,
           );
+          removeTargetStateKeys = [];
+          loadStatesFromLocalStorage();
+          updateStoredStateList();
         },
       });
     }
@@ -1244,10 +1354,7 @@
           }
         }
 
-        localStorage.setItem(
-          localStorageKeyPrefix + "popup-anywhere-states",
-          JSON.stringify(sanitizedStates),
-        );
+        saveStatesToLocalStorage(sanitizedStates);
       }
 
       static restoreDialogState() {
@@ -1672,6 +1779,47 @@
     & + .ui-dialog-buttonpane {
       button {
         height: auto;
+      }
+    }
+
+    .state-list-container {
+      width: 100%;
+      box-sizing: border-box;
+
+      summary {
+        cursor: pointer;
+      }
+
+      .state-list-outer {
+        width: 100%;
+        max-height: 200px;
+        overflow-y: auto;
+        padding: 5px;
+        box-sizing: border-box;
+
+        .state-list {
+          width: 100%;
+
+          .state-active {
+            color: #9c9;
+          }
+
+          .state-to-be-removed {
+            text-decoration: line-through;
+            color: #999;
+            font-style: italic;
+          }
+
+          .state-actions {
+            text-align: center;
+
+            button {
+              margin: 0 5px;
+              height: auto;
+              cursor: pointer;
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request significantly improves the "Popup Anywhere" settings panel by adding a user interface for managing stored popup states, including the ability to view, remove, and cancel removal of saved states. It also introduces related UI enhancements, internationalization updates, and code refactoring for better maintainability.

**Stored State Management UI:**
- Added a new section in the settings panel that lists all stored popup states, shows their details, and allows users to remove or cancel removal of individual states. The list highlights the active state and prevents its removal. ([app/views/enhanced_ux/layouts/_popup_anywhere.html.erbR318-R394](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951R318-R394), F5e454d1L434R434, F5e454d1L479R479, F5e454d1L173R173, F5e454d1L1797R1797)

**Internationalization and UI Text:**
- Updated both English and Japanese resource strings to support new labels, messages, and descriptions for the stored state management features. This includes tooltips, button labels, and user guidance. ([app/views/enhanced_ux/layouts/_popup_anywhere.html.erbR61-R75](diffhunk://#diff-44c07ecd9d1af2de6bdc30a3a6a010897e8309d9e3f3d93cd662979377205951R61-R75), F5e454d1L102R102)

**Settings Panel Enhancements:**
- Increased the dialog width to accommodate the new state management UI and added descriptive tooltips for relevant settings (e.g., max stored state count). (F5e454d1L294R294, F5e454d1L416R416, F5e454d1L434R434)

**Code Refactoring:**
- Introduced a reusable `saveStatesToLocalStorage` function and refactored state-saving logic to use it, improving code clarity and maintainability. (F5e454d1L173R173, F5e454d1L1370R1370)

**Styling Updates:**
- Added CSS to style the new stored state list, including visual cues for active and to-be-removed states, and improved overall layout for better usability. (F5e454d1L1797R1797)