### PR TITLE
fix: limit interpolate-size scope to project-index

### DIFF
--- a/app/views/enhanced_ux/projects/_custom_project_list.html.erb
+++ b/app/views/enhanced_ux/projects/_custom_project_list.html.erb
@@ -803,7 +803,7 @@
   })();
 </script>
 <style>
-  :root {
+  #projects-index:has(:is(.toggle-subprojects, .link-box)) {
     interpolate-size: allow-keywords;
   }
 


### PR DESCRIPTION
This pull request makes a small change to the CSS in the `app/views/enhanced_ux/projects/_custom_project_list.html.erb` file, scoping the `interpolate-size` property to only apply when `#projects-index` contains elements with the `.toggle-subprojects` or `.link-box` classes.