### PR TITLE
Merge dev Branch: Applying Changes for v1.2.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ To access the plugin's settings:
 - [Redmine Actual Date](https://github.com/sk-ys/redmine_actual_date)
 - [Redmine Datetime CF](https://github.com/sk-ys/redmine_datetime_cf)
 - [Redmine Drafts](https://github.com/jbbarth/redmine_drafts)
+- [Redmine DrawIO](https://github.com/mikitex70/redmine_drawio)
 - [Redmine Extra Notes](http://github.com/sk-ys/redmine_extra_notes)
 - [Redmine GLightbox](http://github.com/sk-ys/redmine_glightbox)
 - [Redmine Issue Note List](https://github.com/sk-ys/redmine_issue_note_list)

--- a/app/views/enhanced_ux/issues/_custom_issue.html.erb
+++ b/app/views/enhanced_ux/issues/_custom_issue.html.erb
@@ -281,7 +281,10 @@
     }
 
     function redrawDrawIOGraph() {
-      if (typeof GraphViewer?.createViewerForElement === "function") {
+      if (
+        typeof GraphViewer !== "undefined" &&
+        typeof GraphViewer?.createViewerForElement === "function"
+      ) {
         $(".mxgraph").each((i, elem) => {
           GraphViewer.createViewerForElement(elem);
         });

--- a/app/views/enhanced_ux/issues/_custom_issue.html.erb
+++ b/app/views/enhanced_ux/issues/_custom_issue.html.erb
@@ -280,6 +280,14 @@
       };
     }
 
+    function redrawDrawIOGraph() {
+      if (typeof GraphViewer?.createViewerForElement === "function") {
+        $(".mxgraph").each((i, elem) => {
+          GraphViewer.createViewerForElement(elem);
+        });
+      }
+    }
+
     window.addEventListener("DOMContentLoaded", function () {
       const controller = [...document.body.classList]
         .filter((i) => i.startsWith("controller"))[0]
@@ -1360,6 +1368,9 @@
           if (window.redmineGLightbox) {
             window.redmineGLightbox.regenerate();
           }
+
+          // Redraw DrawIO graph if exists
+          redrawDrawIOGraph();
         }
 
         /**
@@ -1381,7 +1392,7 @@
                       node.nodeType === Node.ELEMENT_NODE &&
                       $(node).is("div.issue.details")
                     ) {
-                      this.handleFormReplacement();
+                      this.handleIssueViewReplacement();
                     }
                   });
                 }
@@ -1396,9 +1407,10 @@
           }
         }
 
-        handleFormReplacement() {
+        handleIssueViewReplacement() {
           console.log("Issue view replacement detected.");
           this.resetHeightOfAttachmentTable();
+          redrawDrawIOGraph();
         }
 
         #setupFixedIssueSubject() {

--- a/app/views/enhanced_ux/layouts/_direct_edit_on_issue_list.html.erb
+++ b/app/views/enhanced_ux/layouts/_direct_edit_on_issue_list.html.erb
@@ -205,7 +205,7 @@
         const actionOrIssueId =
           $selectedIssueIds.length > 1
             ? "bulk_update"
-            : $selectedIssueIds.val();
+            : encodeURIComponent($selectedIssueIds.val());
         const isCustomField = key.startsWith("cf_");
         const cfId = isCustomField ? key.split("_")[1] : null;
 

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -13,6 +13,7 @@
       initialHeight: 600,
       maxStoredStateCount: 5,
       disablePopupInPopup: true,
+      inheritPopupSizeFromActiveWindow: true,
     };
 
     // Target link query
@@ -58,6 +59,7 @@
         labelInitialHeight: "Initial height",
         labelMaxStoredStateCount: "Max stored state count",
         labelDisablePopupInPopup: "Disable popup in popup",
+        labelInheritPopupSizeFromActiveWindow: "Inherit size from active popup",
         labelReset: "Reset",
         labelSave: "Save",
         labelCancel: "Cancel",
@@ -92,6 +94,8 @@
         labelInitialHeight: "初期高さ",
         labelMaxStoredStateCount: "最大状態保持数",
         labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
+        labelInheritPopupSizeFromActiveWindow:
+          "アクティブなポップアップサイズを引き継ぐ",
         labelReset: "リセット",
         labelSave: "保存",
         labelCancel: "キャンセル",
@@ -308,6 +312,14 @@
             $("<input>").attr("type", "checkbox"),
             settings.disablePopupInPopup,
           ),
+        )
+        .append(
+          generateSettingItem(
+            resources.labelInheritPopupSizeFromActiveWindow,
+            "pa_get_popup_size_from_active_window_settings",
+            $("<input>").attr("type", "checkbox"),
+            settings.inheritPopupSizeFromActiveWindow,
+          ),
         );
 
       const $dialog = $settingsPanel.dialog({
@@ -346,6 +358,9 @@
                 disablePopupInPopup: $(
                   "#pa_disable_popup_in_popup_settings",
                 ).prop("checked"),
+                inheritPopupSizeFromActiveWindow: $(
+                  "#pa_get_popup_size_from_active_window_settings",
+                ).prop("checked"),
               });
               saveSettings();
               $dialog.dialog("close");
@@ -372,6 +387,10 @@
           $("#pa_disable_popup_in_popup_settings").prop(
             "checked",
             settings.disablePopupInPopup,
+          );
+          $("#pa_get_popup_size_from_active_window_settings").prop(
+            "checked",
+            settings.inheritPopupSizeFromActiveWindow,
           );
         },
       });
@@ -1262,11 +1281,25 @@
         $("body").addClass(`popup-anywhere-flex-${state.flexDirection}`);
       }
 
+      storeDialogSize() {
+        const $dialog = this.$dialog;
+        if (
+          $dialog.dialogPA("option", "minimized") ||
+          $dialog.dialogPA("option", "maximized")
+        )
+          return;
+
+        const width = $dialog.dialogPA("option", "width");
+        const height = $dialog.dialogPA("option", "height");
+        PopUp.size.width = width;
+        PopUp.size.height = height;
+      }
+
       constructor(
         url,
         positionAt = null,
-        height = PopUp.size.height,
-        width = PopUp.size.width,
+        height = null,
+        width = null,
         maximized = false,
         minimized = false,
         fixed = false,
@@ -1275,8 +1308,18 @@
 
         this.url = url;
         this.positionAt = positionAt;
-        this.height = height;
-        this.width = width;
+        this.height =
+          height !== null
+            ? height
+            : settings.inheritPopupSizeFromActiveWindow
+              ? PopUp.size.height
+              : settings.initialHeight;
+        this.width =
+          width !== null
+            ? width
+            : settings.inheritPopupSizeFromActiveWindow
+              ? PopUp.size.width
+              : settings.initialWidth;
         this.maximized = maximized;
         this.minimized = minimized;
         this.fixed = fixed;
@@ -1331,18 +1374,10 @@
             });
           },
           resizeStop: () => {
-            if (
-              this.$dialog.dialogPA("option", "minimized") ||
-              this.$dialog.dialogPA("option", "maximized")
-            )
-              return;
-
-            // Back up the current size
-            const height = this.$dialog.dialogPA("option", "height");
-            PopUp.size.height = height;
-
-            const width = this.$dialog.dialogPA("option", "width");
-            PopUp.size.width = width;
+            this.storeDialogSize();
+          },
+          focus: () => {
+            this.storeDialogSize();
           },
         });
       }

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -9,8 +9,8 @@
   $(function () {
     // ----- settings start -----
     const defaultSettings = {
-      width: 1000,
-      height: 600,
+      initialWidth: 1000,
+      initialHeight: 600,
       maxStoredStateCount: 5,
       disablePopupInPopup: true,
     };
@@ -105,6 +105,31 @@
       ...settingsFromLocalStorage,
     };
     const settings = window.enhancedUxPopupAnywhereSettings;
+
+    function saveSettings() {
+      localStorage.setItem(
+        localStorageKeyPrefix + "popup-anywhere-settings",
+        JSON.stringify(settings),
+      );
+    }
+
+    const states = {};
+    function loadStatesFromLocalStorage() {
+      const loadedStates = JSON.parse(
+        localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-states") ||
+        localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-state") ||
+          "{}",
+      );
+      Object.keys(states).forEach((key) => delete states[key]);
+      Object.assign(states, loadedStates);
+
+      // Remove old localStorage keys
+      localStorage.removeItem(localStorageKeyPrefix + "popup-anywhere-state");
+
+      // Remove unused parameters
+      delete states["_default-width"];
+      delete states["_default-height"];
+    }
 
     const svgIcons = new (class SVGIcons {
       constructor() {
@@ -902,57 +927,27 @@
       },
     });
 
+    const lastPopupSize = {
+      width: settings.initialWidth,
+      height: settings.initialHeight,
+    };
     class PopUp {
       static size = {
         get width() {
-          const states =
-            JSON.parse(
-              localStorage.getItem(
-                localStorageKeyPrefix + "popup-anywhere-state",
-              ),
-            ) || {};
-          return states["_default-width"] ?? settings.width;
+          return lastPopupSize.width;
         },
         set width(value) {
-          const states =
-            JSON.parse(
-              localStorage.getItem(
-                localStorageKeyPrefix + "popup-anywhere-state",
-              ),
-            ) || {};
-          states["_default-width"] = value;
-          localStorage.setItem(
-            localStorageKeyPrefix + "popup-anywhere-state",
-            JSON.stringify(states),
-          );
+          lastPopupSize.width = value;
         },
         get height() {
-          const states =
-            JSON.parse(
-              localStorage.getItem(
-                localStorageKeyPrefix + "popup-anywhere-state",
-              ),
-            ) || {};
-          return states["_default-height"] ?? settings.height;
+          return lastPopupSize.height;
         },
         set height(value) {
-          const states =
-            JSON.parse(
-              localStorage.getItem(
-                localStorageKeyPrefix + "popup-anywhere-state",
-              ),
-            ) || {};
-          states["_default-height"] = value;
-          localStorage.setItem(
-            localStorageKeyPrefix + "popup-anywhere-state",
-            JSON.stringify(states),
-          );
+          lastPopupSize.height = value;
         },
       };
 
       static dialogSelector = "body > .ui-dialog.popup-anywhere";
-
-      static specialStorageKeys = ["_default-width", "_default-height"];
 
       static getActiveDialogs() {
         return $(PopUp.dialogSelector).map((_, e) =>
@@ -987,12 +982,9 @@
       }
 
       static saveDialogState() {
-        const states =
-          JSON.parse(
-            localStorage.getItem(
-              localStorageKeyPrefix + "popup-anywhere-state",
-            ),
-          ) || {};
+        // Load the latest states from localStorage to avoid overwriting changes
+        // made in other tabs
+        loadStatesFromLocalStorage();
 
         if (PopUp.getActiveDialogs().length === 0) {
           delete states[location.pathname];
@@ -1033,8 +1025,7 @@
 
           // Delete undefined timestamp objects
           for (const [key, value] of Object.entries(states)) {
-            if (PopUp.specialStorageKeys.includes(key)) continue;
-            if (value.timeStamp === undefined) {
+            if (!value.timeStamp) {
               delete states[key];
             }
           }
@@ -1042,18 +1033,16 @@
           // Delete old timestamp objects
           while (
             Object.keys(states).length >
-            settings.maxStoredStateCount + PopUp.specialStorageKeys.length
+            settings.maxStoredStateCount
           ) {
             const oldestTimeStamp = Math.min(
               ...Object.keys(states)
-                .filter((key) => !PopUp.specialStorageKeys.includes(key))
                 .map((k) => {
                   return Number(states[k].timeStamp);
                 }),
             );
 
             for (const [key, value] of Object.entries(states)) {
-              if (PopUp.specialStorageKeys.includes(key)) continue;
               if (Number(value.timeStamp) === oldestTimeStamp) {
                 delete states[key];
                 break;
@@ -1069,7 +1058,6 @@
         // Remove title from the state to avoid storing unnecessary data
         const sanitizedStates = JSON.parse(JSON.stringify(states));
         for (const [key, value] of Object.entries(sanitizedStates)) {
-          if (PopUp.specialStorageKeys.includes(key)) continue;
           if (value.dialogs) {
             value.dialogs.forEach((dialog) => {
               delete dialog.title;
@@ -1078,15 +1066,12 @@
         }
 
         localStorage.setItem(
-          localStorageKeyPrefix + "popup-anywhere-state",
+          localStorageKeyPrefix + "popup-anywhere-states",
           JSON.stringify(sanitizedStates),
         );
       }
 
       static restoreDialogState() {
-        const states = JSON.parse(
-          localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-state"),
-        );
         if (states === null || states[location.pathname] === undefined) return;
         const state = states[location.pathname];
         state.dialogs
@@ -1224,12 +1209,15 @@
 
     function Initialize() {
       replaceClickEventsForAllAnchorTags();
+      loadStatesFromLocalStorage();
       PopUp.restoreDialogState();
       window.addEventListener(
         "beforeunload",
         (e) => {
           if (window === window.parent || !settings.disablePopupInPopup) {
+            loadStatesFromLocalStorage();
             PopUp.saveDialogState();
+            saveSettings();
           }
         },
         { capture: true },

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -25,10 +25,10 @@
     const MaximumNumberOfStates = 5;
     // ----- settings end -----
 
-    const homeUrl = ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
-      .attr("src")
-      ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)
-      ?.[1] || "") + "/";
+    const homeUrl =
+      ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
+        .attr("src")
+        ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)?.[1] || "") + "/";
     const localStorageKeyPrefix = homeUrl.slice(1).replaceAll("/", ".");
 
     // i18n
@@ -107,7 +107,7 @@
         return $(
           `<svg class="s18 icon-svg" aria-hidden="true">` +
             `<use href="${this.basePath}#${key}"></use>` +
-            `</svg>`
+            `</svg>`,
         );
       }
       get loader() {
@@ -148,7 +148,7 @@
       },
       isInternalUrl: (url) => {
         return RegExp("^" + utils.getAbsUrl(homeUrl)).test(
-          utils.getAbsUrl(url)
+          utils.getAbsUrl(url),
         );
       },
     };
@@ -273,7 +273,7 @@
         return Math.max(
           this.options.minWidth,
           document.body.clientWidth -
-            (this.uiDialog.outerWidth() - this.uiDialog.width())
+            (this.uiDialog.outerWidth() - this.uiDialog.width()),
         );
       },
 
@@ -414,7 +414,7 @@
             $unMinimizedDialogs.each((_, e) => {
               $(e)
                 .filter(
-                  (_, e) => !$(e).parent().hasClass("popup-anywhere-maximize")
+                  (_, e) => !$(e).parent().hasClass("popup-anywhere-maximize"),
                 )
                 .dialogPA("storeSizeAndPosition");
             });
@@ -519,11 +519,11 @@
 
         const width = Math.min(
           this.storedSizeAndPosition.width,
-          this.options.minimized ? this.options.widthAtMinimized : maxWidth
+          this.options.minimized ? this.options.widthAtMinimized : maxWidth,
         );
         const height = Math.min(
           this.storedSizeAndPosition.height,
-          this.options.minimized ? this._dialogHeightAtMinimized : maxHeight
+          this.options.minimized ? this._dialogHeightAtMinimized : maxHeight,
         );
         if (resize) this._resizeDialog(width, height);
         if (move) {
@@ -531,7 +531,7 @@
           const top = Math.max(this.storedSizeAndPosition.position.top, 0);
           this._moveDialog(
             left + width > maxWidth ? maxWidth - width : left,
-            top + height > maxHeight ? maxHeight - height : top
+            top + height > maxHeight ? maxHeight - height : top,
           );
         }
       },
@@ -567,7 +567,7 @@
           !(
             $("body").hasClass("popup-anywhere-flex") ||
             this.uiDialog.siblings(
-              ".ui-dialog.popup-anywhere.popup-anywhere-maximize"
+              ".ui-dialog.popup-anywhere.popup-anywhere-maximize",
             ).length > 0
           )
         ) {
@@ -821,7 +821,7 @@
             this.$btnForward.button(
               "option",
               "disabled",
-              this.history.pos >= this.history.list.length - 1
+              this.history.pos >= this.history.list.length - 1,
             );
 
             // Set title
@@ -871,11 +871,13 @@
             });
 
             // Hide sticky issue header
-            $contents.find("head").append(
-              $("<style>").text(
-                "#sticky-issue-header { display: none !important; }"
-              ).addClass("added-by-popup-anywhere hide-sticky-header")
-            );
+            $contents
+              .find("head")
+              .append(
+                $("<style>")
+                  .text("#sticky-issue-header { display: none !important; }")
+                  .addClass("added-by-popup-anywhere hide-sticky-header"),
+              );
 
             $(e.target).css("visibility", "");
           })
@@ -887,30 +889,48 @@
     class PopUp {
       static size = {
         get width() {
-          const states = JSON.parse(localStorage.getItem(
-            localStorageKeyPrefix + "popup-anywhere-state")) || {};
+          const states =
+            JSON.parse(
+              localStorage.getItem(
+                localStorageKeyPrefix + "popup-anywhere-state",
+              ),
+            ) || {};
           return states["_default-width"] ?? initialWidth;
         },
         set width(value) {
-          const states = JSON.parse(localStorage.getItem(
-              localStorageKeyPrefix + "popup-anywhere-state")) || {};
+          const states =
+            JSON.parse(
+              localStorage.getItem(
+                localStorageKeyPrefix + "popup-anywhere-state",
+              ),
+            ) || {};
           states["_default-width"] = value;
           localStorage.setItem(
             localStorageKeyPrefix + "popup-anywhere-state",
-            JSON.stringify(states));
+            JSON.stringify(states),
+          );
         },
         get height() {
-          const states = JSON.parse(localStorage.getItem(
-            localStorageKeyPrefix + "popup-anywhere-state")) || {};
+          const states =
+            JSON.parse(
+              localStorage.getItem(
+                localStorageKeyPrefix + "popup-anywhere-state",
+              ),
+            ) || {};
           return states["_default-height"] ?? initialHeight;
         },
         set height(value) {
-          const states = JSON.parse(localStorage.getItem(
-            localStorageKeyPrefix + "popup-anywhere-state")) || {};
+          const states =
+            JSON.parse(
+              localStorage.getItem(
+                localStorageKeyPrefix + "popup-anywhere-state",
+              ),
+            ) || {};
           states["_default-height"] = value;
           localStorage.setItem(
             localStorageKeyPrefix + "popup-anywhere-state",
-            JSON.stringify(states));
+            JSON.stringify(states),
+          );
         },
       };
 
@@ -920,7 +940,7 @@
 
       static getActiveDialogs() {
         return $(PopUp.dialogSelector).map((_, e) =>
-          $(e).children(".ui-dialog-content")
+          $(e).children(".ui-dialog-content"),
         );
       }
 
@@ -937,7 +957,7 @@
 
       static getActiveDialog(excludeElem) {
         const zIndices = PopUp.getDialogZIndices().filter(
-          (o) => !excludeElem || o.ui[0] !== excludeElem
+          (o) => !excludeElem || o.ui[0] !== excludeElem,
         );
         if (zIndices.length === 0) return undefined;
         const highestZIndex = Math.max(...zIndices.map((i) => i.zIndex));
@@ -946,14 +966,17 @@
 
       static getUnMinimizedDialogs() {
         return $(PopUp.dialogSelector + ":not(.popup-anywhere-minimize)").map(
-          (_, e) => $(e).children(".ui-dialog-content")
+          (_, e) => $(e).children(".ui-dialog-content"),
         );
       }
 
       static saveDialogState() {
         const states =
-          JSON.parse(localStorage.getItem(
-            localStorageKeyPrefix + "popup-anywhere-state")) || {};
+          JSON.parse(
+            localStorage.getItem(
+              localStorageKeyPrefix + "popup-anywhere-state",
+            ),
+          ) || {};
 
         if (PopUp.getActiveDialogs().length === 0) {
           delete states[location.pathname];
@@ -973,7 +996,7 @@
                     $(e)
                       .children(".ui-dialog-content")
                       .find("iframe")
-                      .attr("src")
+                      .attr("src"),
                   ) === false
                 );
               })
@@ -1010,7 +1033,7 @@
                 .filter((key) => !PopUp.specialStorageKeys.includes(key))
                 .map((k) => {
                   return Number(states[k].timeStamp);
-                })
+                }),
             );
 
             for (const [key, value] of Object.entries(states)) {
@@ -1026,7 +1049,7 @@
         if (states[location.pathname]?.dialogs?.length === 0) {
           delete states[location.pathname];
         }
-        
+
         // Remove title from the state to avoid storing unnecessary data
         const sanitizedStates = JSON.parse(JSON.stringify(states));
         for (const [key, value] of Object.entries(sanitizedStates)) {
@@ -1040,12 +1063,14 @@
 
         localStorage.setItem(
           localStorageKeyPrefix + "popup-anywhere-state",
-          JSON.stringify(sanitizedStates));
+          JSON.stringify(sanitizedStates),
+        );
       }
 
       static restoreDialogState() {
-        const states = JSON.parse(localStorage.getItem(
-          localStorageKeyPrefix + "popup-anywhere-state"));
+        const states = JSON.parse(
+          localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-state"),
+        );
         if (states === null || states[location.pathname] === undefined) return;
         const state = states[location.pathname];
         state.dialogs
@@ -1062,7 +1087,7 @@
                 dialogProps.width,
                 dialogProps.maximized,
                 dialogProps.minimized,
-                dialogProps.fixed
+                dialogProps.fixed,
               );
             } catch (e) {
               console.error(e);
@@ -1083,7 +1108,7 @@
         width = PopUp.size.width,
         maximized = false,
         minimized = false,
-        fixed = false
+        fixed = false,
       ) {
         if (!url) throw new Error("url must not be null");
 
@@ -1105,7 +1130,7 @@
           this.$dialog.prepend(
             $("<div>")
               .addClass("popup-anywhere-container-loading-icon")
-              .append(svgIcons.loader)
+              .append(svgIcons.loader),
           );
         } else {
           this.$dialog.css({
@@ -1191,7 +1216,7 @@
             PopUp.saveDialogState();
           }
         },
-        { capture: true }
+        { capture: true },
       );
     }
 
@@ -1204,7 +1229,11 @@
   .ui-dialog.popup-anywhere:not(.ui-dialog-resizing):not(
       .ui-dialog-dragging
     ):not(.ui-dialog-position-changing) {
-    transition: width 0.5s, height 0.5s, top 0.5s, left 0.5s;
+    transition:
+      width 0.5s,
+      height 0.5s,
+      top 0.5s,
+      left 0.5s;
   }
 
   .ui-dialog.popup-anywhere {
@@ -1253,11 +1282,11 @@
 
       /* Stop animation when iframe is visible */
       &:is(
-          .ui-dialog-content.popup-anywhere-container:not(
-              :has(iframe[style*="visibility: hidden;"])
-            )
-            *
-        ) {
+        .ui-dialog-content.popup-anywhere-container:not(
+            :has(iframe[style*="visibility: hidden;"])
+          )
+          *
+      ) {
         display: none;
       }
     }

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -117,7 +117,9 @@
     function loadStatesFromLocalStorage() {
       const loadedStates = JSON.parse(
         localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-states") ||
-        localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-state") ||
+          localStorage.getItem(
+            localStorageKeyPrefix + "popup-anywhere-state",
+          ) ||
           "{}",
       );
       Object.keys(states).forEach((key) => delete states[key]);
@@ -157,6 +159,15 @@
     })();
 
     const isRtl = $('head link[rel="stylesheet"][href*="/rtl"]').length > 0;
+
+    const isIframe = window !== window.parent;
+    if (isIframe && settings.disablePopupInPopup) {
+      // Prevent popup in popup if the setting is enabled
+      console.log(
+        "Popup Anywhere: Popup in popup is disabled. Exiting script.",
+      );
+      return;
+    }
 
     const utils = {
       getAbsUrl: (url) => {
@@ -1031,15 +1042,11 @@
           }
 
           // Delete old timestamp objects
-          while (
-            Object.keys(states).length >
-            settings.maxStoredStateCount
-          ) {
+          while (Object.keys(states).length > settings.maxStoredStateCount) {
             const oldestTimeStamp = Math.min(
-              ...Object.keys(states)
-                .map((k) => {
-                  return Number(states[k].timeStamp);
-                }),
+              ...Object.keys(states).map((k) => {
+                return Number(states[k].timeStamp);
+              }),
             );
 
             for (const [key, value] of Object.entries(states)) {
@@ -1214,7 +1221,7 @@
       window.addEventListener(
         "beforeunload",
         (e) => {
-          if (window === window.parent || !settings.disablePopupInPopup) {
+          if (!isIframe || !settings.disablePopupInPopup) {
             loadStatesFromLocalStorage();
             PopUp.saveDialogState();
             saveSettings();

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -58,6 +58,9 @@
         labelInitialWidth: "Initial width",
         labelInitialHeight: "Initial height",
         labelMaxStoredStateCount: "Max stored state count",
+        descOverMaxStoredStateCount:
+          "If the number of stored states exceeds this value, " +
+          "the oldest states will be removed automatically.",
         labelDisablePopupInPopup: "Disable popup in popup",
         labelInheritPopupSizeFromActiveWindow: "Inherit size from active popup",
         labelReset: "Reset",
@@ -100,6 +103,8 @@
         labelInitialWidth: "初期幅",
         labelInitialHeight: "初期高さ",
         labelMaxStoredStateCount: "ルールの最大保持数",
+        descOverMaxStoredStateCount:
+          "ルールの最大保持数を超えた場合、古いルールから自動的に削除されます。",
         labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
         labelInheritPopupSizeFromActiveWindow:
           "アクティブなポップアップサイズを引き継ぐ",
@@ -111,7 +116,8 @@
         labelStoredStates: "保存済みのルール",
         labelNItems: "%{count} 件",
         messageRemoveThisState: "このルールを削除します",
-        messageActiveStateCannotBeRemoved: "アクティブなルールは削除できません。",
+        messageActiveStateCannotBeRemoved:
+          "アクティブなルールは削除できません。",
         messageCancelRemovingThisState: "このルールの削除をキャンセルします",
       },
     };
@@ -288,9 +294,18 @@
         "popup-anywhere-settings-panel-content",
       );
 
-      function generateSettingItem(labelText, id, $input, value = false) {
+      function generateSettingItem(
+        labelText,
+        id,
+        $input,
+        value = false,
+        labelTitle = null,
+      ) {
         const $container = $("<div>").addClass("setting-item");
         const $label = $("<label>").text(labelText).attr("for", id);
+        if (labelTitle) {
+          $label.attr("title", labelTitle);
+        }
         $input
           .attr("id", id)
           .prop(
@@ -401,6 +416,7 @@
             "pa_max_stored_state_count_settings",
             $("<input>").attr({ type: "number", min: 0, step: 1 }),
             settings.maxStoredStateCount,
+            resources.descOverMaxStoredStateCount,
           ),
         )
         .append(

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -63,6 +63,13 @@
         labelReset: "Reset",
         labelSave: "Save",
         labelCancel: "Cancel",
+        labelRemove: "Remove",
+        labelActive: "Active",
+        labelStoredStates: "Stored States",
+        labelNItems: "%{count} item(s)",
+        messageRemoveThisState: "Remove this state",
+        messageActiveStateCannotBeRemoved: "Active state can not be removed.",
+        messageCancelRemovingThisState: "Cancel removing this state",
       },
       ja: {
         labelClose: "閉じる",
@@ -92,13 +99,20 @@
         labelSettings: "設定",
         labelInitialWidth: "初期幅",
         labelInitialHeight: "初期高さ",
-        labelMaxStoredStateCount: "最大状態保持数",
+        labelMaxStoredStateCount: "ルールの最大保持数",
         labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
         labelInheritPopupSizeFromActiveWindow:
           "アクティブなポップアップサイズを引き継ぐ",
         labelReset: "リセット",
         labelSave: "保存",
         labelCancel: "キャンセル",
+        labelRemove: "削除",
+        labelActive: "アクティブ",
+        labelStoredStates: "保存済みのルール",
+        labelNItems: "%{count} 件",
+        messageRemoveThisState: "このルールを削除します",
+        messageActiveStateCannotBeRemoved: "アクティブなルールは削除できません。",
+        messageCancelRemovingThisState: "このルールの削除をキャンセルします",
       },
     };
     const resources = {
@@ -151,6 +165,13 @@
       // Remove unused parameters
       delete states["_default-width"];
       delete states["_default-height"];
+    }
+
+    function saveStatesToLocalStorage(newStates = states) {
+      localStorage.setItem(
+        localStorageKeyPrefix + "popup-anywhere-states",
+        JSON.stringify(newStates),
+      );
     }
 
     const svgIcons = new (class SVGIcons {
@@ -279,6 +300,83 @@
         return $container.append($label).append($input);
       }
 
+      function generateStoredStateListContainer() {
+        const $stateListContainer = $("<details>").addClass(
+          "state-list-container",
+        );
+        const $stateListOuter = $("<div>").addClass("state-list-outer");
+        const $stateList = $("<table>").addClass("state-list");
+        return $stateListContainer
+          .append($("<summary>").text(resources.labelStoredStates))
+          .append($stateListOuter.append($stateList));
+      }
+
+      let removeTargetStateKeys = [];
+      function updateStoredStateList() {
+        const $stateList = $settingsPanel.find(".state-list");
+        $stateList.empty();
+        Object.keys(states).forEach((key) => {
+          const $tr = $("<tr>");
+          const $tdKey = $("<td>")
+            .append(
+              key === location.pathname
+                ? $("<span>").text(key)
+                : $("<a>")
+                    .attr({
+                      href: key,
+                      target: "_blank",
+                    })
+                    .text(key),
+            )
+            .attr({
+              title: new Date(states[key]?.timeStamp).toLocaleString(),
+            });
+          const $tdItemCount = $("<td>")
+            .text(
+              resources.labelNItems.replace(
+                "%{count}",
+                states[key]?.dialogs?.length || 0,
+              ),
+            )
+            .attr(
+              "title",
+              states[key]?.dialogs
+                ?.map((dialog, index) => index + 1 + ": " + dialog.src)
+                .join("\n"),
+            );
+          const $tdAction = $("<td>").addClass("state-actions");
+          if (key === location.pathname) {
+            $tr.addClass("state-active");
+            $tdAction
+              .append($("<span>").text(resources.labelActive))
+              .attr("title", resources.messageActiveStateCannotBeRemoved);
+          } else if (removeTargetStateKeys.includes(key)) {
+            $tr.addClass("state-to-be-removed");
+            const $cancelBtn = $("<button>")
+              .text(resources.labelCancel)
+              .attr("title", resources.messageCancelRemovingThisState)
+              .on("click", () => {
+                removeTargetStateKeys = removeTargetStateKeys.filter(
+                  (k) => k !== key,
+                );
+                updateStoredStateList();
+              });
+            $tdAction.append($cancelBtn);
+          } else {
+            const $removeBtn = $("<button>")
+              .text(resources.labelRemove)
+              .attr("title", resources.messageRemoveThisState)
+              .on("click", () => {
+                removeTargetStateKeys.push(key);
+                updateStoredStateList();
+              });
+            $tdAction.append($removeBtn);
+          }
+          $tr.append($tdKey).append($tdItemCount).append($tdAction);
+          $stateList.append($tr);
+        });
+      }
+
       // Append settings to dialog
       $settingsPanel
         .append(
@@ -320,13 +418,15 @@
             $("<input>").attr("type", "checkbox"),
             settings.inheritPopupSizeFromActiveWindow,
           ),
-        );
+        )
+        .append($("<hr>"))
+        .append(generateStoredStateListContainer());
 
       const $dialog = $settingsPanel.dialog({
         autoOpen: false,
         title: "Popup Anywhere - " + resources.labelSettings,
         modal: true,
-        width: 350,
+        width: 500,
         resizable: false,
         buttons: [
           {
@@ -363,6 +463,13 @@
                 ).prop("checked"),
               });
               saveSettings();
+              if (removeTargetStateKeys.length > 0) {
+                removeTargetStateKeys.forEach((key) => {
+                  delete states[key];
+                });
+                removeTargetStateKeys = [];
+                saveStatesToLocalStorage();
+              }
               $dialog.dialog("close");
             },
           },
@@ -392,6 +499,9 @@
             "checked",
             settings.inheritPopupSizeFromActiveWindow,
           );
+          removeTargetStateKeys = [];
+          loadStatesFromLocalStorage();
+          updateStoredStateList();
         },
       });
     }
@@ -1244,10 +1354,7 @@
           }
         }
 
-        localStorage.setItem(
-          localStorageKeyPrefix + "popup-anywhere-states",
-          JSON.stringify(sanitizedStates),
-        );
+        saveStatesToLocalStorage(sanitizedStates);
       }
 
       static restoreDialogState() {
@@ -1672,6 +1779,47 @@
     & + .ui-dialog-buttonpane {
       button {
         height: auto;
+      }
+    }
+
+    .state-list-container {
+      width: 100%;
+      box-sizing: border-box;
+
+      summary {
+        cursor: pointer;
+      }
+
+      .state-list-outer {
+        width: 100%;
+        max-height: 200px;
+        overflow-y: auto;
+        padding: 5px;
+        box-sizing: border-box;
+
+        .state-list {
+          width: 100%;
+
+          .state-active {
+            color: #9c9;
+          }
+
+          .state-to-be-removed {
+            text-decoration: line-through;
+            color: #999;
+            font-style: italic;
+          }
+
+          .state-actions {
+            text-align: center;
+
+            button {
+              margin: 0 5px;
+              height: auto;
+              cursor: pointer;
+            }
+          }
+        }
       }
     }
   }

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -1003,17 +1003,17 @@
             Object.keys(states).length >
             MaximumNumberOfStates + PopUp.specialStorageKeys.length
           ) {
-            const maxTimeStamp = Math.max(
+            const oldestTimeStamp = Math.min(
               ...Object.keys(states)
                 .filter((key) => !PopUp.specialStorageKeys.includes(key))
                 .map((k) => {
-                  Number(states[k].timeStamp);
+                  return Number(states[k].timeStamp);
                 })
             );
 
             for (const [key, value] of Object.entries(states)) {
               if (PopUp.specialStorageKeys.includes(key)) continue;
-              if (value.timeStamp === maxTimeStamp) {
+              if (Number(value.timeStamp) === oldestTimeStamp) {
                 delete states[key];
                 break;
               }

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -8,8 +8,12 @@
   //<![CDATA[
   $(function () {
     // ----- settings start -----
-    let initialWidth = 1000;
-    let initialHeight = 600;
+    const defaultSettings = {
+      width: 1000,
+      height: 600,
+      maxStoredStateCount: 5,
+      disablePopupInPopup: true,
+    };
 
     // Target link query
     const targetLinkQueries =
@@ -21,15 +25,7 @@
       ":not(a.prevent-popup-anywhere)";
 
     const modalMode = false;
-    const disablePopupInPopup = true;
-    const MaximumNumberOfStates = 5;
     // ----- settings end -----
-
-    const homeUrl =
-      ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
-        .attr("src")
-        ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)?.[1] || "") + "/";
-    const localStorageKeyPrefix = homeUrl.slice(1).replaceAll("/", ".");
 
     // i18n
     const resourcesAll = {
@@ -89,6 +85,26 @@
       ...resourcesAll["en"],
       ...(resourcesAll[document.documentElement.lang] || {}),
     };
+
+    const homeUrl =
+      ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
+        .attr("src")
+        ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)?.[1] || "") + "/";
+    const localStorageKeyPrefix = homeUrl.slice(1).replaceAll("/", ".");
+
+    // Load user settings from localStorage
+    const settingsFromLocalStorage = JSON.parse(
+      localStorage.getItem(localStorageKeyPrefix + "popup-anywhere-settings") ||
+        "{}",
+    );
+
+    // Merge user settings with default settings
+    window.enhancedUxPopupAnywhereSettings = {
+      ...defaultSettings,
+      ...window.enhancedUxPopupAnywhereSettings,
+      ...settingsFromLocalStorage,
+    };
+    const settings = window.enhancedUxPopupAnywhereSettings;
 
     const svgIcons = new (class SVGIcons {
       constructor() {
@@ -861,7 +877,7 @@
                 }
               }
             }
-            if (disablePopupInPopup) {
+            if (settings.disablePopupInPopup) {
               $contents.find("a").addClass("prevent-popup-anywhere");
             }
 
@@ -895,7 +911,7 @@
                 localStorageKeyPrefix + "popup-anywhere-state",
               ),
             ) || {};
-          return states["_default-width"] ?? initialWidth;
+          return states["_default-width"] ?? settings.width;
         },
         set width(value) {
           const states =
@@ -917,7 +933,7 @@
                 localStorageKeyPrefix + "popup-anywhere-state",
               ),
             ) || {};
-          return states["_default-height"] ?? initialHeight;
+          return states["_default-height"] ?? settings.height;
         },
         set height(value) {
           const states =
@@ -1026,7 +1042,7 @@
           // Delete old timestamp objects
           while (
             Object.keys(states).length >
-            MaximumNumberOfStates + PopUp.specialStorageKeys.length
+            settings.maxStoredStateCount + PopUp.specialStorageKeys.length
           ) {
             const oldestTimeStamp = Math.min(
               ...Object.keys(states)
@@ -1212,7 +1228,7 @@
       window.addEventListener(
         "beforeunload",
         (e) => {
-          if (window === window.parent) {
+          if (window === window.parent || !settings.disablePopupInPopup) {
             PopUp.saveDialogState();
           }
         },

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -56,6 +56,7 @@
         labelRowDirection: "Aligned in row direction",
         labelColumnDirection: "Aligned in column direction",
         messageCloseAllDialogs: "Close all dialogs?",
+        messageLoading: "Loading...",
       },
       ja: {
         labelClose: "閉じる",
@@ -81,6 +82,7 @@
         labelRowDirection: "行方向に整列",
         labelColumnDirection: "列方向に整列",
         messageCloseAllDialogs: "全てのダイアログを閉じますか？",
+        messageLoading: "読み込み中...",
       },
     };
     const resources = {
@@ -1024,10 +1026,21 @@
         if (states[location.pathname]?.dialogs?.length === 0) {
           delete states[location.pathname];
         }
+        
+        // Remove title from the state to avoid storing unnecessary data
+        const sanitizedStates = JSON.parse(JSON.stringify(states));
+        for (const [key, value] of Object.entries(sanitizedStates)) {
+          if (PopUp.specialStorageKeys.includes(key)) continue;
+          if (value.dialogs) {
+            value.dialogs.forEach((dialog) => {
+              delete dialog.title;
+            });
+          }
+        }
 
         localStorage.setItem(
           localStorageKeyPrefix + "popup-anywhere-state",
-          JSON.stringify(states));
+          JSON.stringify(sanitizedStates));
       }
 
       static restoreDialogState() {
@@ -1043,7 +1056,6 @@
           .forEach((dialogProps) => {
             try {
               new PopUp(
-                dialogProps.title,
                 dialogProps.src,
                 dialogProps.positionAt,
                 dialogProps.height,
@@ -1065,7 +1077,6 @@
       }
 
       constructor(
-        title,
         url,
         positionAt = null,
         height = PopUp.size.height,
@@ -1076,7 +1087,6 @@
       ) {
         if (!url) throw new Error("url must not be null");
 
-        this.title = title;
         this.url = url;
         this.positionAt = positionAt;
         this.height = height;
@@ -1086,7 +1096,7 @@
         this.fixed = fixed;
 
         this.$dialog = $("<div>")
-          .attr("title", title)
+          .attr("title", resources.messageLoading)
           .addClass("popup-anywhere-container")
           .data("height", this.height)
           .data("width", this.width);
@@ -1158,10 +1168,9 @@
         .on("click.popup-anywhere", targetLinkQueries, (e) => {
           if (e.ctrlKey) {
             const $anchor = $(e.target).closest("a");
-            const title = $anchor.text();
             const href = $anchor.attr("href");
             if (href && utils.isInternalUrl(href)) {
-              new PopUp(title, href);
+              new PopUp(href);
               e.preventDefault();
               e.stopPropagation();
             } else {

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -53,6 +53,14 @@
         labelColumnDirection: "Aligned in column direction",
         messageCloseAllDialogs: "Close all dialogs?",
         messageLoading: "Loading...",
+        labelSettings: "Settings",
+        labelInitialWidth: "Initial width",
+        labelInitialHeight: "Initial height",
+        labelMaxStoredStateCount: "Max stored state count",
+        labelDisablePopupInPopup: "Disable popup in popup",
+        labelReset: "Reset",
+        labelSave: "Save",
+        labelCancel: "Cancel",
       },
       ja: {
         labelClose: "閉じる",
@@ -79,6 +87,14 @@
         labelColumnDirection: "列方向に整列",
         messageCloseAllDialogs: "全てのダイアログを閉じますか？",
         messageLoading: "読み込み中...",
+        labelSettings: "設定",
+        labelInitialWidth: "初期幅",
+        labelInitialHeight: "初期高さ",
+        labelMaxStoredStateCount: "最大状態保持数",
+        labelDisablePopupInPopup: "ポップアップ内ポップアップを無効化",
+        labelReset: "リセット",
+        labelSave: "保存",
+        labelCancel: "キャンセル",
       },
     };
     const resources = {
@@ -238,6 +254,127 @@
       get list() {
         return this.#list;
       }
+    }
+
+    let $settingsPanel = null;
+    function initSettingsPanel() {
+      $settingsPanel = $("<div>").attr(
+        "id",
+        "popup-anywhere-settings-panel-content",
+      );
+
+      function generateSettingItem(labelText, id, $input, value = false) {
+        const $container = $("<div>").addClass("setting-item");
+        const $label = $("<label>").text(labelText).attr("for", id);
+        $input
+          .attr("id", id)
+          .prop(
+            $input.attr("type") === "checkbox" ? "checked" : "value",
+            value,
+          );
+        return $container.append($label).append($input);
+      }
+
+      // Append settings to dialog
+      $settingsPanel
+        .append(
+          generateSettingItem(
+            resources.labelInitialWidth,
+            "pa_initial_width_settings",
+            $("<input>").attr({ type: "number", min: 100, step: 10 }),
+            settings.initialWidth,
+          ),
+        )
+        .append(
+          generateSettingItem(
+            resources.labelInitialHeight,
+            "pa_initial_height_settings",
+            $("<input>").attr({ type: "number", min: 100, step: 10 }),
+            settings.initialHeight,
+          ),
+        )
+        .append(
+          generateSettingItem(
+            resources.labelMaxStoredStateCount,
+            "pa_max_stored_state_count_settings",
+            $("<input>").attr({ type: "number", min: 0, step: 1 }),
+            settings.maxStoredStateCount,
+          ),
+        )
+        .append(
+          generateSettingItem(
+            resources.labelDisablePopupInPopup,
+            "pa_disable_popup_in_popup_settings",
+            $("<input>").attr("type", "checkbox"),
+            settings.disablePopupInPopup,
+          ),
+        );
+
+      const $dialog = $settingsPanel.dialog({
+        autoOpen: false,
+        title: "Popup Anywhere - " + resources.labelSettings,
+        modal: true,
+        width: 350,
+        resizable: false,
+        buttons: [
+          {
+            text: resources.labelReset,
+            click() {
+              // Reset settings to default
+              Object.assign(settings, defaultSettings);
+              localStorage.removeItem(
+                localStorageKeyPrefix + "popup-anywhere-settings",
+              );
+              saveSettings();
+              $dialog.dialog("close");
+            },
+          },
+          {
+            text: resources.labelSave,
+            click() {
+              // Update settings
+              Object.assign(settings, {
+                initialWidth: parseInt(
+                  $("#pa_initial_width_settings").prop("value"),
+                ),
+                initialHeight: parseInt(
+                  $("#pa_initial_height_settings").prop("value"),
+                ),
+                maxStoredStateCount: parseInt(
+                  $("#pa_max_stored_state_count_settings").prop("value"),
+                ),
+                disablePopupInPopup: $(
+                  "#pa_disable_popup_in_popup_settings",
+                ).prop("checked"),
+              });
+              saveSettings();
+              $dialog.dialog("close");
+            },
+          },
+          {
+            text: resources.labelCancel,
+            click() {
+              $dialog.dialog("close");
+            },
+          },
+        ],
+        open() {
+          // Set current settings values to inputs
+          $("#pa_initial_width_settings").prop("value", settings.initialWidth);
+          $("#pa_initial_height_settings").prop(
+            "value",
+            settings.initialHeight,
+          );
+          $("#pa_max_stored_state_count_settings").prop(
+            "value",
+            settings.maxStoredStateCount,
+          );
+          $("#pa_disable_popup_in_popup_settings").prop(
+            "checked",
+            settings.disablePopupInPopup,
+          );
+        },
+      });
     }
 
     // Extend jQuery UI Dialog Widget
@@ -656,6 +793,21 @@
       },
 
       _addButtonsToDialogTitlebar: function () {
+        const $btnSettings = $("<button>")
+          .addClass("ui-button-popup-anywhere-setting")
+          .button({
+            icon: "ui-icon-gear",
+            label: resources.labelSetting,
+            showLabel: false,
+          })
+          .attr("title", resources.labelSettings)
+          .click(() => {
+            if (!$settingsPanel) {
+              initSettingsPanel();
+            }
+            $settingsPanel.dialog("open");
+          });
+
         const $btnFlex = $("<button>")
           .button({
             icon: "ui-icon-calculator",
@@ -822,6 +974,7 @@
 
         this.uiDialogTitlebarButtonGroup = $("<div>")
           .addClass("ui-dialog-titlebar-button-group")
+          .append($btnSettings)
           .append($btnFlex)
           .append($btnDisableFlex)
           .append($btnFlexDirectionColumn)
@@ -1215,6 +1368,7 @@
     }
 
     function Initialize() {
+      initSettingsPanel();
       replaceClickEventsForAllAnchorTags();
       loadStatesFromLocalStorage();
       PopUp.restoreDialogState();
@@ -1224,7 +1378,6 @@
           if (!isIframe || !settings.disablePopupInPopup) {
             loadStatesFromLocalStorage();
             PopUp.saveDialogState();
-            saveSettings();
           }
         },
         { capture: true },
@@ -1453,6 +1606,38 @@
     .ui-dialog.popup-anywhere .ui-dialog-titlebar-button-group {
       right: auto;
       left: 30px;
+    }
+  }
+
+  /* Settings panel */
+  #popup-anywhere-settings-panel-content {
+    .setting-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+
+    label {
+      font-size: 0.9em;
+      font-weight: normal;
+      cursor: pointer;
+    }
+
+    input[type="number"] {
+      width: 60px;
+      text-align: right;
+      padding: 0;
+    }
+
+    input[type="checkbox"] {
+      margin-right: 5px;
+    }
+
+    & + .ui-dialog-buttonpane {
+      button {
+        height: auto;
+      }
     }
   }
 </style>

--- a/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
+++ b/app/views/enhanced_ux/layouts/_popup_anywhere.html.erb
@@ -1623,7 +1623,8 @@
   }
 
   /* Prevent iframe interaction during dragging or resizing */
-  .popup-anywhere:is(.ui-dialog-dragging, .ui-dialog-resizing) iframe {
+  body:has(.popup-anywhere:is(.ui-dialog-dragging, .ui-dialog-resizing))
+    iframe {
     pointer-events: none !important;
   }
 

--- a/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
+++ b/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
@@ -180,6 +180,15 @@
         }
         return false;
       },
+      getRelativeUrlPath: function (url) {
+        try {
+          const parsedUrl = new URL(url, location.origin);
+          return parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+        } catch (e) {
+          console.log(e);
+        }
+        return url;
+      },
       generateIssueUrl: function (issueId) {
         return location.origin + homeUrl + "issues/" + issueId;
       },
@@ -1483,7 +1492,7 @@
             return;
           }
           this.status.set({
-            src: this.issuePane.$base.data("src").replace(location.origin, "")
+            src: utils.getRelativeUrlPath(this.issuePane.$base.data("src")),
           });
         } else {
           this.issuePane.hide();

--- a/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
+++ b/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
@@ -31,7 +31,7 @@
       "time_entries",
       "issue_note_list",
     ];
-    const storageNameForSrc = localStorageKeyPrefix + "2-pane-mode-src";
+    const storageNameForSharedIssueId = localStorageKeyPrefix + "2-pane-mode-shared-issue-id";
     const storageNameForEachPage = localStorageKeyPrefix + "2-pane-mode-" + pageType;
     const classNameForOpenedItem = "two-pane-mode-opened-item";
     const newIssueSelector = "a[href*='/issues/new']";
@@ -179,6 +179,9 @@
           console.log(e);
         }
         return false;
+      },
+      generateIssueUrl: function (issueId) {
+        return location.origin + homeUrl + "issues/" + issueId;
       },
     };
 
@@ -541,7 +544,20 @@
         const loadedStatus = JSON.parse(
           localStorage.getItem(storageNameForEachPage) || "{}"
         );
-        loadedStatus.src = localStorage.getItem(storageNameForSrc);
+        const sharedIssueId = Number(
+          localStorage.getItem(storageNameForSharedIssueId)
+        );
+        if (
+          !isNaN(sharedIssueId) &&
+          utils.existIssueIdInIssueList(sharedIssueId)) {
+          loadedStatus.src = utils.generateIssueUrl(sharedIssueId);
+        } else if (
+          !isNaN(Number(loadedStatus.issueId)) &&
+          utils.existIssueIdInIssueList(Number(loadedStatus.issueId))) {
+          loadedStatus.src = utils.generateIssueUrl(
+            Number(loadedStatus.issueId)
+          );
+        }
         // console.debug("status.load", loadedStatus);
 
         if (!["Column", "Row"].includes(loadedStatus.direction)) {
@@ -579,10 +595,17 @@
 
       save() {
         // console.debug("status.save", this.current);
-        localStorage.setItem(storageNameForSrc, this.current.src);
+        const issueId = utils.getIssueIdFromIssueUrl(this.current.src);
+        if (issueId) {
+          localStorage.setItem(storageNameForSharedIssueId, issueId);
+        }
+
+        const statusToSave = {...this.current};
+        delete statusToSave.src;
+        statusToSave.issueId = issueId;
         localStorage.setItem(
           storageNameForEachPage,
-          JSON.stringify(this.current)
+          JSON.stringify(statusToSave)
         );
       }
 
@@ -1459,7 +1482,9 @@
             this.issuePane.openUrlIfIssueExistOrNew(this.status.current.src);
             return;
           }
-          this.status.set({ src: this.issuePane.$base.data("src") });
+          this.status.set({
+            src: this.issuePane.$base.data("src").replace(location.origin, "")
+          });
         } else {
           this.issuePane.hide();
         }

--- a/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
+++ b/app/views/enhanced_ux/layouts/_two_pane_mode.html.erb
@@ -12,10 +12,10 @@
     const widthOfWindowToForceSwitchToRowView = 1280;
     // ----- settings end -----
 
-    const homeUrl = ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
-      .attr("src")
-      ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)
-      ?.[1] || "") + "/";
+    const homeUrl =
+      ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
+        .attr("src")
+        ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)?.[1] || "") + "/";
     const localStorageKeyPrefix = homeUrl.slice(1).replaceAll("/", ".");
     const pageType = (() => {
       const key1 = location.pathname.split("/").slice(-1)[0];
@@ -31,8 +31,10 @@
       "time_entries",
       "issue_note_list",
     ];
-    const storageNameForSharedIssueId = localStorageKeyPrefix + "2-pane-mode-shared-issue-id";
-    const storageNameForEachPage = localStorageKeyPrefix + "2-pane-mode-" + pageType;
+    const storageNameForSharedIssueId =
+      localStorageKeyPrefix + "2-pane-mode-shared-issue-id";
+    const storageNameForEachPage =
+      localStorageKeyPrefix + "2-pane-mode-" + pageType;
     const classNameForOpenedItem = "two-pane-mode-opened-item";
     const newIssueSelector = "a[href*='/issues/new']";
 
@@ -108,7 +110,7 @@
         return $(
           `<svg class="s18 icon-svg" aria-hidden="true">` +
             `<use href="${this.basePath}#${key}"></use>` +
-            `</svg>`
+            `</svg>`,
         );
       }
       get loader() {
@@ -276,7 +278,7 @@
             .toArray()
             .map((item) => $(item).attr("id"))
             .filter(
-              (item) => item !== undefined && /^issue\-[0-9]+$/.test(item)
+              (item) => item !== undefined && /^issue\-[0-9]+$/.test(item),
             )
             .map((item) => Number(item.slice(6)))
             .indexOf(issueId) >= 0
@@ -329,7 +331,7 @@
         $("#roadmap")
           .scrollTop(0)
           .scrollTop(
-            $versionHeader.position().top + $target.position().top - offset
+            $versionHeader.position().top + $target.position().top - offset,
           );
       },
       existIssueIdInIssueList: (issueId) => {
@@ -340,8 +342,8 @@
               Number(
                 $(item)
                   .attr("href")
-                  .match(/\/([0-9]+)$/)[1]
-              )
+                  .match(/\/([0-9]+)$/)[1],
+              ),
             )
             .indexOf(issueId) >= 0
         );
@@ -362,7 +364,7 @@
               .parent()
               .scrollTop(
                 $target.position().top -
-                  $("#content table.list.issues thead").outerHeight()
+                  $("#content table.list.issues thead").outerHeight(),
               );
           },
         },
@@ -404,14 +406,14 @@
               window.resizableSubjectColumn && resizableSubjectColumn();
               window.drawSelectedColumns && drawSelectedColumns();
               $(
-                "#draw_relations, #draw_progress_line, #draw_selected_columns"
+                "#draw_relations, #draw_progress_line, #draw_selected_columns",
               ).change(drawGanttHandler);
               $("div.gantt_subjects .expander").on("click", ganttEntryClick);
             }
             const scriptTag = $(".gantt-table~script", data)
               .toArray()
               .filter((e) =>
-                $(e).text().includes("disable_unavailable_columns")
+                $(e).text().includes("disable_unavailable_columns"),
               )[0];
             const regexExtractUnavailableColumns =
               /disable_unavailable_columns\(\s*'([^']+)'\.split\(\s*','\)/;
@@ -438,7 +440,7 @@
           highlightOpenedItem: (className, targetAnchorSelector, url) => {
             const $issueSubject = $(
               "table.gantt-table div.gantt_subjects div.issue-subject " +
-                `a[href="${url}"]`
+                `a[href="${url}"]`,
             ).closest("div.issue-subject");
             if ($issueSubject.length === 0) return;
 
@@ -446,19 +448,19 @@
             const dataNumberOfRows = $issueSubject.data("number-of-rows");
             $(
               `table.gantt-table div[data-number-of-rows=${dataNumberOfRows}]` +
-                `:not(.tooltip)`
+                `:not(.tooltip)`,
             ).addClass(className);
           },
           existIssueIdInIssueList: (issueId) => {
             return (
               $(
                 "table.gantt-table td.gantt_subjects_column>" +
-                  "div.gantt_subjects_container>div.gantt_subjects>form>div"
+                  "div.gantt_subjects_container>div.gantt_subjects>form>div",
               )
                 .toArray()
                 .map((item) => $(item).attr("id"))
                 .filter(
-                  (item) => item !== undefined && /^issue\-[0-9]+$/.test(item)
+                  (item) => item !== undefined && /^issue\-[0-9]+$/.test(item),
                 )
                 .map((item) => Number(item.slice(6)))
                 .indexOf(issueId) >= 0
@@ -485,7 +487,7 @@
               .parent()
               .scrollTop(
                 $target.position().top -
-                  $("#content table.list.issues thead").outerHeight()
+                  $("#content table.list.issues thead").outerHeight(),
               );
           },
         },
@@ -504,7 +506,8 @@
         time_entries: {
           targetAnchorSelector:
             "table.list.time-entries tr.time-entry>td.issue>a",
-          scrollTargetSelector: "#content div.autoscroll:has(>table.list.time-entries)",
+          scrollTargetSelector:
+            "#content div.autoscroll:has(>table.list.time-entries)",
           updatingTargetSelector: "table.list.time-entries",
           existIssueIdInIssueList: (issueId) => {
             return (
@@ -551,20 +554,22 @@
 
       load() {
         const loadedStatus = JSON.parse(
-          localStorage.getItem(storageNameForEachPage) || "{}"
+          localStorage.getItem(storageNameForEachPage) || "{}",
         );
         const sharedIssueId = Number(
-          localStorage.getItem(storageNameForSharedIssueId)
+          localStorage.getItem(storageNameForSharedIssueId),
         );
         if (
           !isNaN(sharedIssueId) &&
-          utils.existIssueIdInIssueList(sharedIssueId)) {
+          utils.existIssueIdInIssueList(sharedIssueId)
+        ) {
           loadedStatus.src = utils.generateIssueUrl(sharedIssueId);
         } else if (
           !isNaN(Number(loadedStatus.issueId)) &&
-          utils.existIssueIdInIssueList(Number(loadedStatus.issueId))) {
+          utils.existIssueIdInIssueList(Number(loadedStatus.issueId))
+        ) {
           loadedStatus.src = utils.generateIssueUrl(
-            Number(loadedStatus.issueId)
+            Number(loadedStatus.issueId),
           );
         }
         // console.debug("status.load", loadedStatus);
@@ -575,7 +580,7 @@
         }
 
         Object.keys(loadedStatus).forEach((key) =>
-          loadedStatus[key] === undefined ? delete loadedStatus[key] : {}
+          loadedStatus[key] === undefined ? delete loadedStatus[key] : {},
         );
 
         this.current = { ...this.current, ...loadedStatus };
@@ -592,7 +597,7 @@
         });
 
         const changed = Object.keys(params).some(
-          (key) => params[key] !== this.current[key]
+          (key) => params[key] !== this.current[key],
         );
 
         this.current = { ...this.current, ...params };
@@ -609,12 +614,12 @@
           localStorage.setItem(storageNameForSharedIssueId, issueId);
         }
 
-        const statusToSave = {...this.current};
+        const statusToSave = { ...this.current };
         delete statusToSave.src;
         statusToSave.issueId = issueId;
         localStorage.setItem(
           storageNameForEachPage,
-          JSON.stringify(statusToSave)
+          JSON.stringify(statusToSave),
         );
       }
 
@@ -832,7 +837,7 @@
           this.$forwardButton.button(
             "option",
             "disabled",
-            this.#history.pos >= this.#history.list.length - 1
+            this.#history.pos >= this.#history.list.length - 1,
           );
 
           // Update pane title
@@ -855,7 +860,7 @@
           // (Remove unnecessary contents and format the layout)
           $contents
             .find(
-              "#wrapper>div.flyout-menu, #top-menu, #header, #footer, #sidebar"
+              "#wrapper>div.flyout-menu, #top-menu, #header, #footer, #sidebar",
             )
             .remove();
           // Support for the Hide sidebar plugin
@@ -878,11 +883,13 @@
           }
 
           // Hide sticky issue header
-          $contents.find("head").append(
-            $("<style>").text(
-              "#sticky-issue-header { display: none !important; }"
-            ).addClass("added-by-two-pane-mode hide-sticky-header")
-          );
+          $contents
+            .find("head")
+            .append(
+              $("<style>")
+                .text("#sticky-issue-header { display: none !important; }")
+                .addClass("added-by-two-pane-mode hide-sticky-header"),
+            );
 
           // Show iframe contents
           this.$iframe.css("visibility", "");
@@ -970,7 +977,7 @@
           this.$base.prepend(
             $("<div>")
               .addClass("issue-pane-loading-icon")
-              .append(svgIcons.loader)
+              .append(svgIcons.loader),
           );
         } else {
           this.$base.css({
@@ -983,7 +990,7 @@
         // Update data("src") in the issue-pane if issue id is exist.
         try {
           const newUrl = utils.locationToFullPath(
-            this.$iframe.contents()[0].location
+            this.$iframe.contents()[0].location,
           );
           if (newUrl == null) return;
           if (newUrl === this.$base.data("src")) return;
@@ -1147,7 +1154,7 @@
                 "grid-direction-column",
                 "issue-pane-minimize",
                 "grid-direction-row",
-              ].join(" ")
+              ].join(" "),
             );
           $("#content").css({ width: "", boxSizing: "" });
         }
@@ -1177,7 +1184,7 @@
             "icon",
             direction === "Column"
               ? "ui-icon-arrowthick-2-n-s"
-              : "ui-icon-arrowthick-2-e-w"
+              : "ui-icon-arrowthick-2-e-w",
           );
 
         if (saveStatus) {
@@ -1190,7 +1197,7 @@
           this.status.active.direction === "Column" ? "Row" : "Column";
         this.setGridDirection(
           destinationDirection,
-          !this.status.active.rowForce
+          !this.status.active.rowForce,
         );
       }
 
@@ -1298,7 +1305,7 @@
             e.preventDefault();
             this.issuePane.open(url);
             this.enable(true);
-          }
+          },
         );
 
         if (this.config["replaceAnchorTagsAfter"] !== undefined) {
@@ -1404,8 +1411,8 @@
                 .on("click", () => {
                   this.enable(false);
                 })
-                .css({ height: "auto" })
-            )
+                .css({ height: "auto" }),
+            ),
         );
 
         // Initialize
@@ -1433,14 +1440,14 @@
               .on("change", () => {
                 const enabled = $("#enable_2-pane_mode").is(":checked");
                 this.enable(enabled);
-              })
+              }),
           )
           .append(
             $("<label>")
               .attr({
                 for: "enable_2-pane_mode",
               })
-              .text(resources.label2PaneMode)
+              .text(resources.label2PaneMode),
           );
         this.config.insertCheckBox($checkBox);
       }
@@ -1466,7 +1473,7 @@
             this.config.highlightOpenedItem?.(
               classNameForOpenedItem,
               this.config.targetAnchorSelector,
-              url
+              url,
             );
           }
         }
@@ -1526,7 +1533,7 @@
 
           const updatedTarget = $(
             updatingTargetSelector,
-            $("<div>").html(htmlString)
+            $("<div>").html(htmlString),
           ).children();
 
           if (updatedTarget.length === 0) {

--- a/app/views/enhanced_ux/projects/_custom_project_list.html.erb
+++ b/app/views/enhanced_ux/projects/_custom_project_list.html.erb
@@ -803,7 +803,7 @@
   })();
 </script>
 <style>
-  :root {
+  #projects-index:has(:is(.toggle-subprojects, .link-box)) {
     interpolate-size: allow-keywords;
   }
 

--- a/assets/javascripts/issues/issue_attributes_to_link.js
+++ b/assets/javascripts/issues/issue_attributes_to_link.js
@@ -22,10 +22,10 @@ window.addEventListener("DOMContentLoaded", () => {
     },
   ];
 
-  const homeUrl = ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
-    .attr("src")
-    ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)
-    ?.[1] || "") + "/";
+  const homeUrl =
+    ($("head script[src*='/jquery-'][src*='-ui-'][src*='.js']")
+      .attr("src")
+      ?.match(/^(.*?)(?:\/javascripts\/|\/assets\/)/)?.[1] || "") + "/";
 
   const projectIdentifier = $("body")
     .attr("class")
@@ -41,17 +41,19 @@ window.addEventListener("DOMContentLoaded", () => {
       const idValue = $(config.idSelector).val();
       if (idValue == undefined) return;
 
-      const search =
-        `?set_filter=1` +
-        `&f[]=${config.param}` +
-        `&op[${config.param}]==` +
-        `&v[${config.param}][]=${idValue}`;
-
-      const issueListUrl =
-        homeUrl + "projects/" + projectIdentifier + "/issues" + search;
+      const issueListUrl = new URL(
+        homeUrl + "projects/" + projectIdentifier + "/issues",
+        window.location.origin,
+      );
+      issueListUrl.searchParams.set("set_filter", "1");
+      issueListUrl.searchParams.append("f[]", config.param);
+      issueListUrl.searchParams.set(`op[${config.param}]`, "=");
+      issueListUrl.searchParams.append(`v[${config.param}][]`, String(idValue));
 
       targets.each(function () {
-        $(this).html($("<a>").attr("href", issueListUrl).text(this.innerHTML));
+        $(this).replaceWith(
+          $("<a>").attr("href", issueListUrl.toString()).text(this.textContent),
+        );
       });
     });
   }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes related to DrawIO integration and two-pane mode state management, along with minor code quality improvements. The main highlights are the addition of DrawIO graph redraw support after dynamic content updates, improved state persistence for two-pane mode (including cross-page issue selection), and various code style corrections.

**DrawIO Integration:**
* Added a `redrawDrawIOGraph` function to ensure DrawIO graphs are properly redrawn after dynamic content updates, such as AJAX page loads or DOM replacements. This function is called after issue view updates and when the issue view is replaced. [[1]](diffhunk://#diff-438c121e9a153ef8ab084cacd829d8583af17e1a4ad9bf56dc4068faa328e1d3R283-R293) [[2]](diffhunk://#diff-438c121e9a153ef8ab084cacd829d8583af17e1a4ad9bf56dc4068faa328e1d3R1374-R1376) [[3]](diffhunk://#diff-438c121e9a153ef8ab084cacd829d8583af17e1a4ad9bf56dc4068faa328e1d3L1399-R1416)
* Added `Redmine DrawIO` to the plugin list in `README.md`.

**Two-Pane Mode State Management:**
* Improved two-pane mode state persistence by introducing a shared issue ID in localStorage, enabling cross-page issue selection and restoring the correct issue pane on reload. Refactored status loading/saving logic to use this shared ID and to store the issue ID separately from the URL. [[1]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L34-R37) [[2]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L542-R574) [[3]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L582-R622)
* Added utility methods for generating and parsing issue URLs, and for extracting relative paths, to support robust state management.

**Code Quality and Style:**
* Fixed an encoding issue for single-issue updates in direct edit mode by applying `encodeURIComponent` to the issue ID.
* Made minor code style improvements for clarity and consistency, such as adding trailing commas, improving selector formatting, and refactoring for readability in `app/views/enhanced_ux/layouts/_two_pane_mode.html.erb`. [[1]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L15-R18) [[2]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L111-R113) [[3]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L267-R281) [[4]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L320-R334) [[5]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L331-R346) [[6]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L353-R367) [[7]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L395-R416) [[8]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L429-R463) [[9]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L476-R490) [[10]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L495-R510) [[11]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L553-R583) [[12]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L570-R600) [[13]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L803-R840) [[14]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L826-R863) [[15]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L849-R891) [[16]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L941-R980) [[17]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L954-R993) [[18]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L1118-R1157) [[19]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L1148-R1187) [[20]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L1161-R1200) [[21]](diffhunk://#diff-0391ae94a8d9f6ccaa2254060a54b1f39145c35bc3554a282730a0c4abd7d988L1269-R1308)

**Refactoring:**
* Renamed `handleFormReplacement` to `handleIssueViewReplacement` for clarity and ensured DrawIO redraw is triggered during issue view replacement. [[1]](diffhunk://#diff-438c121e9a153ef8ab084cacd829d8583af17e1a4ad9bf56dc4068faa328e1d3L1384-R1398) [[2]](diffhunk://#diff-438c121e9a153ef8ab084cacd829d8583af17e1a4ad9bf56dc4068faa328e1d3L1399-R1416)

These changes collectively improve the user experience when working with enhanced issue views and two-pane navigation, especially when using DrawIO diagrams.